### PR TITLE
Add the functionality to store and retrieve the chief complaints data

### DIFF
--- a/src/main/java/com/iemr/hwc/data/quickConsultation/BenChiefComplaint.java
+++ b/src/main/java/com/iemr/hwc/data/quickConsultation/BenChiefComplaint.java
@@ -345,8 +345,8 @@ public class BenChiefComplaint {
 	public void setConceptID(String conceptID) {
 		this.conceptID = conceptID;
 	}
-private static final Logger logger = LoggerFactory.getLogger(BenChiefComplaint.class);
 
+	private static final Logger logger = LoggerFactory.getLogger(BenChiefComplaint.class);
 
 	public static ArrayList<BenChiefComplaint> getBenChiefComplaintList(JsonObject emrgCasesheet) {
 
@@ -359,12 +359,6 @@ private static final Logger logger = LoggerFactory.getLogger(BenChiefComplaint.c
 			for (JsonElement csobj : emrgCasesheet.getAsJsonArray("chiefComplaintList")) {
 				benChiefComplaint = new BenChiefComplaint();
 
-				// if (emrgCasesheet.has("benVisitID") && !emrgCasesheet.get("benVisitID").isJsonNull())
-				// 	benChiefComplaint.setBenVisitID(emrgCasesheet.get("benVisitID").getAsLong());
-
-				// if (emrgCasesheet.has("visitCode") && !emrgCasesheet.get("visitCode").isJsonNull())
-				// 	benChiefComplaint.setVisitCode(emrgCasesheet.get("visitCode").getAsLong());
-
 				if (emrgCasesheet.has("beneficiaryRegID") && !emrgCasesheet.get("beneficiaryRegID").isJsonNull())
 					benChiefComplaint.setBeneficiaryRegID(emrgCasesheet.get("beneficiaryRegID").getAsLong());
 
@@ -374,9 +368,6 @@ private static final Logger logger = LoggerFactory.getLogger(BenChiefComplaint.c
 
 				JsonObject obj = csobj.getAsJsonObject();
 				
-logger.info("Visit id="+obj.get("benVisitID"));
-logger.info("Visit code="+obj.get("visitCode"));
-
 				if (obj.has("benVisitID") && !obj.get("benVisitID").isJsonNull())
             		benChiefComplaint.setBenVisitID(obj.get("benVisitID").getAsLong());
 

--- a/src/main/java/com/iemr/hwc/data/quickConsultation/BenChiefComplaint.java
+++ b/src/main/java/com/iemr/hwc/data/quickConsultation/BenChiefComplaint.java
@@ -31,6 +31,8 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.annotations.Expose;
@@ -39,6 +41,7 @@ import com.iemr.hwc.annotation.sqlInjectionSafe.SQLInjectionSafe;
 @Entity
 @Table(name = "t_benchiefcomplaint")
 public class BenChiefComplaint {
+	
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Expose
@@ -342,21 +345,25 @@ public class BenChiefComplaint {
 	public void setConceptID(String conceptID) {
 		this.conceptID = conceptID;
 	}
+private static final Logger logger = LoggerFactory.getLogger(BenChiefComplaint.class);
+
 
 	public static ArrayList<BenChiefComplaint> getBenChiefComplaintList(JsonObject emrgCasesheet) {
+
+
 		ArrayList<BenChiefComplaint> resArray = new ArrayList<>();
 		BenChiefComplaint benChiefComplaint = null;
-		// System.out.println("ello");
+		
 		if (emrgCasesheet.has("chiefComplaintList") && !emrgCasesheet.get("chiefComplaintList").isJsonNull()
 				&& emrgCasesheet.get("chiefComplaintList").isJsonArray()) {
 			for (JsonElement csobj : emrgCasesheet.getAsJsonArray("chiefComplaintList")) {
 				benChiefComplaint = new BenChiefComplaint();
 
-				if (emrgCasesheet.has("benVisitID") && !emrgCasesheet.get("benVisitID").isJsonNull())
-					benChiefComplaint.setBenVisitID(emrgCasesheet.get("benVisitID").getAsLong());
+				// if (emrgCasesheet.has("benVisitID") && !emrgCasesheet.get("benVisitID").isJsonNull())
+				// 	benChiefComplaint.setBenVisitID(emrgCasesheet.get("benVisitID").getAsLong());
 
-				if (emrgCasesheet.has("visitCode") && !emrgCasesheet.get("visitCode").isJsonNull())
-					benChiefComplaint.setVisitCode(emrgCasesheet.get("visitCode").getAsLong());
+				// if (emrgCasesheet.has("visitCode") && !emrgCasesheet.get("visitCode").isJsonNull())
+				// 	benChiefComplaint.setVisitCode(emrgCasesheet.get("visitCode").getAsLong());
 
 				if (emrgCasesheet.has("beneficiaryRegID") && !emrgCasesheet.get("beneficiaryRegID").isJsonNull())
 					benChiefComplaint.setBeneficiaryRegID(emrgCasesheet.get("beneficiaryRegID").getAsLong());
@@ -366,6 +373,15 @@ public class BenChiefComplaint {
 					benChiefComplaint.setProviderServiceMapID(emrgCasesheet.get("providerServiceMapID").getAsInt());
 
 				JsonObject obj = csobj.getAsJsonObject();
+				
+logger.info("Visit id="+obj.get("benVisitID"));
+logger.info("Visit code="+obj.get("visitCode"));
+
+				if (obj.has("benVisitID") && !obj.get("benVisitID").isJsonNull())
+            		benChiefComplaint.setBenVisitID(obj.get("benVisitID").getAsLong());
+
+        		if (obj.has("visitCode") && !obj.get("visitCode").isJsonNull())
+            		benChiefComplaint.setVisitCode(obj.get("visitCode").getAsLong());
 
 				if (obj.has("chiefComplaintID") && !obj.get("chiefComplaintID").isJsonNull())
 					benChiefComplaint.setChiefComplaintID(obj.get("chiefComplaintID").getAsInt());

--- a/src/main/java/com/iemr/hwc/service/common/master/CommonMasterServiceImpl.java
+++ b/src/main/java/com/iemr/hwc/service/common/master/CommonMasterServiceImpl.java
@@ -127,7 +127,9 @@ public class CommonMasterServiceImpl implements CommonMaterService {
 				break;
 			case 7: {
 				// 7 : General OPD (QC)
-				nurseMasterData = "No Master Data found for QuickConsultation";
+				// nurseMasterData = "No Master Data found for QuickConsultation";
+				nurseMasterData = ancMasterDataServiceImpl
+						.getCommonNurseMasterDataForGenopdAncNcdcarePnc(visitCategoryID, providerServiceMapID, gender);
 			}
 				break;
 			case (8): {

--- a/src/main/java/com/iemr/hwc/service/quickConsultation/QuickConsultationServiceImpl.java
+++ b/src/main/java/com/iemr/hwc/service/quickConsultation/QuickConsultationServiceImpl.java
@@ -245,20 +245,21 @@ public class QuickConsultationServiceImpl implements QuickConsultationService {
 				Long benPhysicalVitalID = commonNurseServiceImpl
 						.saveBeneficiaryPhysicalVitalDetails(benPhysicalVitalDetail);
 
-		//Chief Complaint QC update
- 				JsonArray chiefComplaintsArray = jsnOBJ.getAsJsonArray("chiefComplaints");
-                if (chiefComplaintsArray != null && chiefComplaintsArray.size() > 0) {
-                    for (JsonElement elem : chiefComplaintsArray) {
-                        JsonObject complaintObj = elem.getAsJsonObject();
-                        complaintObj.addProperty("benVisitID", benVisitID);
-                    }
-                }
 
-                jsnOBJ.add("chiefComplaints", chiefComplaintsArray);
-                Long benChiefComplaintID = saveBeneficiaryChiefComplaint(jsnOBJ);
+			//Chief Complaint QC update
+			Long benChiefComplaintID = null;
+			JsonArray chiefComplaintArray = jsnOBJ.getAsJsonArray("chiefComplaintList");
+			
+			for (JsonElement element : chiefComplaintArray) {
+    			JsonObject complaint = element.getAsJsonObject();
+    			complaint.addProperty("benVisitID", benVisitID);
+    			complaint.addProperty("visitCode", benVisitCode);
+			}
+
+			benChiefComplaintID = saveBeneficiaryChiefComplaint(jsnOBJ);
 
 				if (benAnthropometryID != null && benAnthropometryID > 0 && benPhysicalVitalID != null
-						&& benPhysicalVitalID > 0) {
+						&& benPhysicalVitalID > 0 && benChiefComplaintID != null && benChiefComplaintID > 0) {
 					// Integer i = commonNurseServiceImpl.updateBeneficiaryStatus('N',
 					// benVisitDetailsOBJ.getBeneficiaryRegID());
 
@@ -494,13 +495,18 @@ public class QuickConsultationServiceImpl implements QuickConsultationService {
 		BeneficiaryVisitDetail benVisitDetailsOBJ = commonNurseServiceImpl.getCSVisitDetails(benRegID, visitCode);
 		CDSS cdssObj = commonNurseServiceImpl.getCdssDetails(benRegID, visitCode);
 
+		String benChiefComplaintsJson = commonNurseServiceImpl.getBenChiefComplaints(benRegID, visitCode);
+    	BenChiefComplaint[] complaintsArray = gson.fromJson(benChiefComplaintsJson, BenChiefComplaint[].class);
+    	List<BenChiefComplaint> benChiefComplaints = Arrays.asList(complaintsArray);
+	
+
 		if (null != benVisitDetailsOBJ) {
-
 			resMap.put("benVisitDetails", benVisitDetailsOBJ);
-
-			resMap.put("BenChiefComplaints", commonNurseServiceImpl.getBenChiefComplaints(benRegID, visitCode));
-
 		}
+
+		 if (benChiefComplaints != null && !benChiefComplaints.isEmpty()) {
+	        resMap.put("BenChiefComplaints", benChiefComplaints);
+    	}
 		if(cdssObj != null) {
 			resMap.put("cdss", cdssObj);
 		}


### PR DESCRIPTION
# Description

Jira ID: AMM-1419

Add the functionality to include the chief complaints data to store and retrieve from nurse and doctor module.

# Type of change  

- [ ] Enhancement  

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Chief complaints now include both visit ID and visit code details for each entry, enhancing data accuracy and traceability.

- **Bug Fixes**
	- Chief complaints are now correctly sourced from each individual entry rather than from the overall case sheet, improving data integrity.

- **Improvements**
	- Quick Consultation nurse workflows now provide actual master data for relevant visit categories instead of a static message.
	- Chief complaints are displayed in a more structured format during doctor visit details retrieval, ensuring only valid entries are shown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->