### PR TITLE
replaced e.printStackTrace() with SLF4J logger in PatientExtProvider

### DIFF
--- a/src/main/java/com/iemr/hwc/fhir/provider/patient/PatientExtProvider.java
+++ b/src/main/java/com/iemr/hwc/fhir/provider/patient/PatientExtProvider.java
@@ -16,6 +16,8 @@ import org.hl7.fhir.r4.model.Patient;
 import org.hl7.fhir.r4.model.StringType;
 import org.json.JSONArray;
 import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -41,6 +43,8 @@ import jakarta.servlet.http.HttpServletRequest;
 
 @Component
 public class PatientExtProvider implements IResourceProvider {
+
+    private static final Logger logger = LoggerFactory.getLogger(PatientExtProvider.class);
 
     @Override
     public Class<? extends IBaseResource> getResourceType() {
@@ -171,7 +175,7 @@ public class PatientExtProvider implements IResourceProvider {
             }
         }
         catch (Exception e){
-            e.printStackTrace();
+            logger.error("Error while fetching patient records by location and date", e);
         }
 
         return listRes;
@@ -236,7 +240,7 @@ public class PatientExtProvider implements IResourceProvider {
             }
         }
         catch (Exception e){
-            e.printStackTrace();
+            logger.error("Error while fetching visits by village and last modified date", e);
         }
 
         return listRes;


### PR DESCRIPTION
## 📋 Description

JIRA ID:

`PatientExtProvider.java` has no SLF4J logger declared, so both catch blocks fall back to `e.printStackTrace()`. Every other class in this codebase uses `LoggerFactory.getLogger(...)` so this one was just missed. In production, stdout is not picked up by log aggregators so any exception thrown from these FHIR endpoints disappears silently with no trace in logs.

---

## ✅ Type of Change

- [x] 🐞 **Bug fix** (non-breaking change which resolves an issue)

---

## ℹ️ Additional Information

Added SLF4J imports, declared a logger field on the class, and replaced both `e.printStackTrace()` calls with `logger.error(message, e)`. Logging only change, no behaviour modified. Follows the same pattern used everywhere else in the project.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced error logging for patient and visit data retrieval operations to improve system diagnostics and troubleshooting capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->