### PR TITLE
fix(generalOPD): replace RuntimeException with IEMRException and add unit tests

### DIFF
--- a/src/main/java/com/iemr/hwc/service/generalOPD/GeneralOPDService.java
+++ b/src/main/java/com/iemr/hwc/service/generalOPD/GeneralOPDService.java
@@ -25,17 +25,18 @@ import java.util.Map;
 
 import com.google.gson.JsonObject;
 import com.iemr.hwc.data.nurse.CommonUtilityClass;
+import com.iemr.hwc.utils.exception.IEMRException;
 
 public interface GeneralOPDService {
 
-	String saveNurseData(JsonObject requestOBJ, String Authorization) throws Exception;
-	
+	String saveNurseData(JsonObject requestOBJ, String Authorization) throws IEMRException, Exception;
+
 	void deleteVisitDetails(JsonObject requestOBJ) throws Exception;
 
 	Map<String, Long> saveBenVisitDetails(JsonObject visitDetailsOBJ, CommonUtilityClass nurseUtilityClass)
 			throws Exception;
 
-	Long saveDoctorData(JsonObject requestOBJ, String Authorization) throws Exception;
+	Long saveDoctorData(JsonObject requestOBJ, String Authorization) throws IEMRException, Exception;
 
 	Long saveBenGeneralOPDHistoryDetails(JsonObject generalOPDHistoryOBJ, Long benVisitID, Long benVisitCode)
 			throws Exception;

--- a/src/main/java/com/iemr/hwc/service/generalOPD/GeneralOPDService.java
+++ b/src/main/java/com/iemr/hwc/service/generalOPD/GeneralOPDService.java
@@ -25,18 +25,17 @@ import java.util.Map;
 
 import com.google.gson.JsonObject;
 import com.iemr.hwc.data.nurse.CommonUtilityClass;
-import com.iemr.hwc.utils.exception.IEMRException;
 
 public interface GeneralOPDService {
 
-	String saveNurseData(JsonObject requestOBJ, String Authorization) throws IEMRException, Exception;
+	String saveNurseData(JsonObject requestOBJ, String Authorization) throws Exception;
 
 	void deleteVisitDetails(JsonObject requestOBJ) throws Exception;
 
 	Map<String, Long> saveBenVisitDetails(JsonObject visitDetailsOBJ, CommonUtilityClass nurseUtilityClass)
 			throws Exception;
 
-	Long saveDoctorData(JsonObject requestOBJ, String Authorization) throws IEMRException, Exception;
+	Long saveDoctorData(JsonObject requestOBJ, String Authorization) throws Exception;
 
 	Long saveBenGeneralOPDHistoryDetails(JsonObject generalOPDHistoryOBJ, Long benVisitID, Long benVisitCode)
 			throws Exception;

--- a/src/main/java/com/iemr/hwc/service/generalOPD/GeneralOPDServiceImpl.java
+++ b/src/main/java/com/iemr/hwc/service/generalOPD/GeneralOPDServiceImpl.java
@@ -1008,7 +1008,7 @@ public class GeneralOPDServiceImpl implements GeneralOPDService {
 				throw new IEMRException("Error occurred while saving doctor data");
 			}
 		} else {
-			// request OBJ is null.
+			throw new IEMRException("Invalid input");
 		}
 		return saveSuccessFlag;
 	}
@@ -1658,7 +1658,7 @@ public class GeneralOPDServiceImpl implements GeneralOPDService {
 				throw new IEMRException("Error occurred while updating doctor data");
 			}
 		} else {
-			// request OBJ is null.
+			throw new IEMRException("Invalid input");
 		}
 		return updateSuccessFlag;
 	}

--- a/src/main/java/com/iemr/hwc/service/generalOPD/GeneralOPDServiceImpl.java
+++ b/src/main/java/com/iemr/hwc/service/generalOPD/GeneralOPDServiceImpl.java
@@ -124,7 +124,7 @@ public class GeneralOPDServiceImpl implements GeneralOPDService {
 	/// --------------- start of saving nurse data ------------------------
 	@Override
 	// @Transactional(rollbackFor = Exception.class)
-	public String saveNurseData(JsonObject requestOBJ, String Authorization) throws Exception {
+	public String saveNurseData(JsonObject requestOBJ, String Authorization) throws IEMRException, Exception {
 		Long historySaveSuccessFlag = null;
 		Long vitalSaveSuccessFlag = null;
 		Long examtnSaveSuccessFlag = null;
@@ -177,7 +177,7 @@ public class GeneralOPDServiceImpl implements GeneralOPDService {
 					examtnSaveSuccessFlag = saveBenExaminationDetails(requestOBJ.getAsJsonObject("examinationDetails"),
 							benVisitID, benVisitCode);
 			} else {
-				throw new RuntimeException("Error occurred while creating beneficiary visit");
+				throw new IEMRException("Error occurred while creating beneficiary visit");
 			}
 
 			if ((null != historySaveSuccessFlag && historySaveSuccessFlag > 0)
@@ -207,10 +207,10 @@ public class GeneralOPDServiceImpl implements GeneralOPDService {
 				}
 
 			} else {
-				throw new RuntimeException("Error occurred while saving data");
+				throw new IEMRException("Error occurred while saving data");
 			}
 		} else {
-			throw new Exception("Invalid input");
+			throw new IEMRException("Invalid input");
 		}
 		Map<String, String> responseMap = new HashMap<String, String>();
 		if (benVisitCode != null) {
@@ -811,7 +811,7 @@ public class GeneralOPDServiceImpl implements GeneralOPDService {
 	/// --------------- start of saving doctor data ------------------------
 	@Override
 	@Transactional(rollbackFor = Exception.class)
-	public Long saveDoctorData(JsonObject requestOBJ, String Authorization) throws Exception {
+	public Long saveDoctorData(JsonObject requestOBJ, String Authorization) throws IEMRException, Exception {
 
 		Boolean doctorSignatureFlag = false;
 		if (requestOBJ.has("doctorSignatureFlag")
@@ -993,7 +993,7 @@ public class GeneralOPDServiceImpl implements GeneralOPDService {
 				if (i > 0)
 					saveSuccessFlag = investigationSuccessFlag;
 				else
-					throw new RuntimeException("Error occurred while saving data. Beneficiary status update failed");
+					throw new IEMRException("Error occurred while saving data. Beneficiary status update failed");
 
 				if (i > 0 && tcRequestOBJ != null && tcRequestOBJ.getWalkIn() == false) {
 					int k = sMSGatewayServiceImpl.smsSenderGateway("schedule", commonUtilityClass.getBeneficiaryRegID(),
@@ -1005,7 +1005,7 @@ public class GeneralOPDServiceImpl implements GeneralOPDService {
 				}
 
 			} else {
-				throw new RuntimeException();
+				throw new IEMRException("Error occurred while saving doctor data");
 			}
 		} else {
 			// request OBJ is null.
@@ -1447,7 +1447,7 @@ public class GeneralOPDServiceImpl implements GeneralOPDService {
 
 	// update doctor data
 	@Transactional(rollbackFor = Exception.class)
-	public Long updateGeneralOPDDoctorData(JsonObject requestOBJ, String Authorization) throws Exception {
+	public Long updateGeneralOPDDoctorData(JsonObject requestOBJ, String Authorization) throws IEMRException, Exception {
 
 		Boolean doctorSignatureFlag = false;
 		if (requestOBJ.has("doctorSignatureFlag")
@@ -1643,7 +1643,7 @@ public class GeneralOPDServiceImpl implements GeneralOPDService {
 				if (i > 0)
 					updateSuccessFlag = investigationSuccessFlag;
 				else
-					throw new RuntimeException("Error occurred while saving data. Beneficiary status update failed");
+					throw new IEMRException("Error occurred while updating data. Beneficiary status update failed");
 
 				if (i > 0 && tcRequestOBJ != null && tcRequestOBJ.getWalkIn() == false) {
 					int k = sMSGatewayServiceImpl.smsSenderGateway("schedule", commonUtilityClass.getBeneficiaryRegID(),
@@ -1655,7 +1655,7 @@ public class GeneralOPDServiceImpl implements GeneralOPDService {
 				}
 
 			} else {
-				throw new RuntimeException();
+				throw new IEMRException("Error occurred while updating doctor data");
 			}
 		} else {
 			// request OBJ is null.

--- a/src/main/java/com/iemr/hwc/service/generalOPD/GeneralOPDServiceImpl.java
+++ b/src/main/java/com/iemr/hwc/service/generalOPD/GeneralOPDServiceImpl.java
@@ -124,7 +124,7 @@ public class GeneralOPDServiceImpl implements GeneralOPDService {
 	/// --------------- start of saving nurse data ------------------------
 	@Override
 	// @Transactional(rollbackFor = Exception.class)
-	public String saveNurseData(JsonObject requestOBJ, String Authorization) throws IEMRException, Exception {
+	public String saveNurseData(JsonObject requestOBJ, String Authorization) throws Exception {
 		Long historySaveSuccessFlag = null;
 		Long vitalSaveSuccessFlag = null;
 		Long examtnSaveSuccessFlag = null;
@@ -811,7 +811,7 @@ public class GeneralOPDServiceImpl implements GeneralOPDService {
 	/// --------------- start of saving doctor data ------------------------
 	@Override
 	@Transactional(rollbackFor = Exception.class)
-	public Long saveDoctorData(JsonObject requestOBJ, String Authorization) throws IEMRException, Exception {
+	public Long saveDoctorData(JsonObject requestOBJ, String Authorization) throws Exception {
 
 		Boolean doctorSignatureFlag = false;
 		if (requestOBJ.has("doctorSignatureFlag")
@@ -1447,7 +1447,7 @@ public class GeneralOPDServiceImpl implements GeneralOPDService {
 
 	// update doctor data
 	@Transactional(rollbackFor = Exception.class)
-	public Long updateGeneralOPDDoctorData(JsonObject requestOBJ, String Authorization) throws IEMRException, Exception {
+	public Long updateGeneralOPDDoctorData(JsonObject requestOBJ, String Authorization) throws Exception {
 
 		Boolean doctorSignatureFlag = false;
 		if (requestOBJ.has("doctorSignatureFlag")

--- a/src/test/java/com/iemr/hwc/service/login/IemrMmuLoginServiceImplTest.java
+++ b/src/test/java/com/iemr/hwc/service/login/IemrMmuLoginServiceImplTest.java
@@ -1,0 +1,196 @@
+/*
+* AMRIT – Accessible Medical Records via Integrated Technology
+* Integrated EHR (Electronic Health Records) Solution
+*
+* Copyright (C) "Piramal Swasthya Management and Research Institute"
+*
+* This file is part of AMRIT.
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see https://www.gnu.org/licenses/.
+*/
+package com.iemr.hwc.service.login;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.iemr.hwc.repo.login.MasterVanRepo;
+import com.iemr.hwc.repo.login.ServicePointVillageMappingRepo;
+import com.iemr.hwc.repo.login.UserParkingplaceMappingRepo;
+import com.iemr.hwc.repo.login.UserVanSpDetails_View_Repo;
+import com.iemr.hwc.repo.login.VanServicepointMappingRepo;
+
+@ExtendWith(MockitoExtension.class)
+class IemrMmuLoginServiceImplTest {
+
+    @Mock
+    private UserParkingplaceMappingRepo userParkingplaceMappingRepo;
+    @Mock
+    private MasterVanRepo masterVanRepo;
+    @Mock
+    private VanServicepointMappingRepo vanServicepointMappingRepo;
+    @Mock
+    private ServicePointVillageMappingRepo servicePointVillageMappingRepo;
+    @Mock
+    private UserVanSpDetails_View_Repo userVanSpDetails_View_Repo;
+
+    @InjectMocks
+    private IemrMmuLoginServiceImpl loginService;
+
+    private static final Integer USER_ID = 101;
+    private static final Integer PROVIDER_SERVICE_MAP_ID = 202;
+    private static final Integer SERVICE_POINT_ID = 303;
+
+    // -------------------- getUserServicePointVanDetails --------------------
+
+    @Test
+    void getUserServicePointVanDetails_noParkingPlace_returnsEmptyResponseMap() {
+        when(userParkingplaceMappingRepo.getUserParkingPlce(USER_ID))
+                .thenReturn(Collections.emptyList());
+
+        String result = loginService.getUserServicePointVanDetails(USER_ID);
+
+        assertNotNull(result);
+        assertEquals("{}", result);
+    }
+
+    @Test
+    void getUserServicePointVanDetails_withParkingPlace_returnsMappedResponse() {
+        List<Object[]> parkingList = new ArrayList<>();
+        parkingList.add(new Object[]{1, 10, "StateName", 20, "DistrictName", 30, "BlockName"});
+        when(userParkingplaceMappingRepo.getUserParkingPlce(USER_ID)).thenReturn(parkingList);
+
+        List<Object[]> vanList = new ArrayList<>();
+        vanList.add(new Object[]{5, "VAN-001"});
+        when(masterVanRepo.getUserVanDatails(anySet())).thenReturn(vanList);
+
+        List<Object[]> spList = new ArrayList<>();
+        spList.add(new Object[]{7, "ServicePoint1", "SESSION_TYPE"});
+        when(vanServicepointMappingRepo.getuserSpSessionDetails(anySet())).thenReturn(spList);
+
+        String result = loginService.getUserServicePointVanDetails(USER_ID);
+
+        assertNotNull(result);
+        assertTrue(result.contains("userVanDetails"));
+        assertTrue(result.contains("userSpDetails"));
+        assertTrue(result.contains("parkingPlaceLocationList"));
+    }
+
+    @Test
+    void getUserServicePointVanDetails_emptyVanList_addsEmptyVanEntry() {
+        List<Object[]> parkingList = new ArrayList<>();
+        parkingList.add(new Object[]{1, 10, "StateName", 20, "DistrictName", 30, "BlockName"});
+        when(userParkingplaceMappingRepo.getUserParkingPlce(USER_ID)).thenReturn(parkingList);
+
+        when(masterVanRepo.getUserVanDatails(anySet())).thenReturn(Collections.emptyList());
+        when(vanServicepointMappingRepo.getuserSpSessionDetails(anySet())).thenReturn(Collections.emptyList());
+
+        String result = loginService.getUserServicePointVanDetails(USER_ID);
+
+        assertNotNull(result);
+        assertTrue(result.contains("userVanDetails"));
+    }
+
+    // -------------------- getServicepointVillages --------------------
+
+    @Test
+    void getServicepointVillages_withVillages_returnsMappedList() {
+        List<Object[]> villageList = new ArrayList<>();
+        villageList.add(new Object[]{1, "Village A"});
+        when(servicePointVillageMappingRepo.getServicePointVillages(SERVICE_POINT_ID))
+                .thenReturn(villageList);
+
+        String result = loginService.getServicepointVillages(SERVICE_POINT_ID);
+
+        assertNotNull(result);
+        assertTrue(result.contains("Village A"));
+    }
+
+    @Test
+    void getServicepointVillages_noVillages_returnsEmptyJsonArray() {
+        when(servicePointVillageMappingRepo.getServicePointVillages(SERVICE_POINT_ID))
+                .thenReturn(Collections.emptyList());
+
+        String result = loginService.getServicepointVillages(SERVICE_POINT_ID);
+
+        assertEquals("[]", result);
+    }
+
+    // -------------------- getUserVanSpDetails --------------------
+
+    @Test
+    void getUserVanSpDetails_withVanSpData_returnsUserVanAndLocDetails() {
+        ArrayList<Object[]> spList = new ArrayList<>();
+        spList.add(new Object[]{1, 2, "VanName", (short) 1, 3, "SpName", 4, 5});
+        when(userVanSpDetails_View_Repo.getUserVanSpDetails_View(USER_ID, PROVIDER_SERVICE_MAP_ID))
+                .thenReturn(spList);
+
+        List<Object[]> parkingList = new ArrayList<>();
+        parkingList.add(new Object[]{10, 20, "State", 30, "District", 40, "Block"});
+        when(userParkingplaceMappingRepo.getUserParkingPlce(USER_ID)).thenReturn(parkingList);
+
+        String result = loginService.getUserVanSpDetails(USER_ID, PROVIDER_SERVICE_MAP_ID);
+
+        assertNotNull(result);
+        assertTrue(result.contains("UserVanSpDetails"));
+        assertTrue(result.contains("UserLocDetails"));
+    }
+
+    @Test
+    void getUserVanSpDetails_emptyVanSpList_returnsEmptyUserVanSpDetails() {
+        when(userVanSpDetails_View_Repo.getUserVanSpDetails_View(USER_ID, PROVIDER_SERVICE_MAP_ID))
+                .thenReturn(new ArrayList<>());
+        when(userParkingplaceMappingRepo.getUserParkingPlce(USER_ID))
+                .thenReturn(Collections.emptyList());
+
+        String result = loginService.getUserVanSpDetails(USER_ID, PROVIDER_SERVICE_MAP_ID);
+
+        assertNotNull(result);
+        assertTrue(result.contains("UserVanSpDetails"));
+    }
+
+    // -------------------- getUserSpokeDetails --------------------
+
+    @Test
+    void getUserSpokeDetails_withVans_returnsListIncludingAllEntry() {
+        ArrayList<Object[]> vanList = new ArrayList<>();
+        vanList.add(new Object[]{1, "Spoke Van 1"});
+        when(masterVanRepo.getVanMaster(PROVIDER_SERVICE_MAP_ID)).thenReturn(vanList);
+
+        String result = loginService.getUserSpokeDetails(PROVIDER_SERVICE_MAP_ID);
+
+        assertNotNull(result);
+        assertTrue(result.contains("All"));
+        assertTrue(result.contains("Spoke Van 1"));
+    }
+
+    @Test
+    void getUserSpokeDetails_noVans_returnsOnlyAllEntry() {
+        when(masterVanRepo.getVanMaster(PROVIDER_SERVICE_MAP_ID)).thenReturn(new ArrayList<>());
+
+        String result = loginService.getUserSpokeDetails(PROVIDER_SERVICE_MAP_ID);
+
+        assertNotNull(result);
+        assertTrue(result.contains("All"));
+    }
+}

--- a/src/test/java/com/iemr/hwc/service/ncdscreening/NCDScreeningServiceImplTest.java
+++ b/src/test/java/com/iemr/hwc/service/ncdscreening/NCDScreeningServiceImplTest.java
@@ -1,0 +1,248 @@
+/*
+* AMRIT – Accessible Medical Records via Integrated Technology
+* Integrated EHR (Electronic Health Records) Solution
+*
+* Copyright (C) "Piramal Swasthya Management and Research Institute"
+*
+* This file is part of AMRIT.
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see https://www.gnu.org/licenses/.
+*/
+package com.iemr.hwc.service.ncdscreening;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.iemr.hwc.data.ncdScreening.BreastCancerScreening;
+import com.iemr.hwc.data.ncdScreening.CbacDetails;
+import com.iemr.hwc.data.ncdScreening.CervicalCancerScreening;
+import com.iemr.hwc.data.ncdScreening.DiabetesScreening;
+import com.iemr.hwc.data.ncdScreening.HypertensionScreening;
+import com.iemr.hwc.data.ncdScreening.OralCancerScreening;
+import com.iemr.hwc.repo.nurse.ncdscreening.BreastCancerScreeningRepo;
+import com.iemr.hwc.repo.nurse.ncdscreening.CbacDetailsRepo;
+import com.iemr.hwc.repo.nurse.ncdscreening.CervicalCancerScreeningRepo;
+import com.iemr.hwc.repo.nurse.ncdscreening.DiabetesScreeningRepo;
+import com.iemr.hwc.repo.nurse.ncdscreening.HypertensionScreeningRepo;
+import com.iemr.hwc.repo.nurse.ncdscreening.OralCancerScreeningRepo;
+import com.iemr.hwc.utils.exception.IEMRException;
+
+@ExtendWith(MockitoExtension.class)
+class NCDScreeningServiceImplTest {
+
+    @Mock
+    private DiabetesScreeningRepo diabetesScreeningRepo;
+    @Mock
+    private HypertensionScreeningRepo hypertensionScreeningRepo;
+    @Mock
+    private OralCancerScreeningRepo oralCancerScreeningRepo;
+    @Mock
+    private BreastCancerScreeningRepo breastCancerScreeningRepo;
+    @Mock
+    private CervicalCancerScreeningRepo cervicalCancerScreeningRepo;
+    @Mock
+    private CbacDetailsRepo cbacDetailsRepo;
+
+    @InjectMocks
+    private NCDScreeningServiceImpl ncdScreeningService;
+
+    private DiabetesScreening diabetesScreening;
+    private HypertensionScreening hypertensionScreening;
+    private OralCancerScreening oralCancerScreening;
+    private BreastCancerScreening breastCancerScreening;
+    private CervicalCancerScreening cervicalCancerScreening;
+    private CbacDetails cbacDetails;
+
+    @BeforeEach
+    void setUp() {
+        diabetesScreening = new DiabetesScreening();
+        diabetesScreening.setId(1L);
+
+        hypertensionScreening = new HypertensionScreening();
+        hypertensionScreening.setId(1L);
+
+        oralCancerScreening = new OralCancerScreening();
+        oralCancerScreening.setId(1L);
+
+        breastCancerScreening = new BreastCancerScreening();
+        breastCancerScreening.setId(1L);
+
+        cervicalCancerScreening = new CervicalCancerScreening();
+        cervicalCancerScreening.setId(1L);
+
+        cbacDetails = new CbacDetails();
+        cbacDetails.setId(1L);
+    }
+
+    // -------------------- saveDiabetesDetails --------------------
+
+    @Test
+    void saveDiabetesDetails_success_returnsId() throws IEMRException {
+        when(diabetesScreeningRepo.save(diabetesScreening)).thenReturn(diabetesScreening);
+
+        Long result = ncdScreeningService.saveDiabetesDetails(diabetesScreening);
+
+        assertEquals(1L, result);
+        verify(diabetesScreeningRepo).save(diabetesScreening);
+    }
+
+    @Test
+    void saveDiabetesDetails_repoReturnsNull_throwsIEMRException() {
+        when(diabetesScreeningRepo.save(diabetesScreening)).thenReturn(null);
+
+        IEMRException ex = assertThrows(IEMRException.class,
+                () -> ncdScreeningService.saveDiabetesDetails(diabetesScreening));
+
+        assertEquals("Error while saving diabetes screening data", ex.getMessage());
+    }
+
+    @Test
+    void saveDiabetesDetails_repoReturnsObjectWithNullId_throwsIEMRException() {
+        DiabetesScreening noId = new DiabetesScreening();
+        when(diabetesScreeningRepo.save(noId)).thenReturn(noId);
+
+        IEMRException ex = assertThrows(IEMRException.class,
+                () -> ncdScreeningService.saveDiabetesDetails(noId));
+
+        assertEquals("Error while saving diabetes screening data", ex.getMessage());
+    }
+
+    // -------------------- saveHypertensionDetails --------------------
+
+    @Test
+    void saveHypertensionDetails_success_returnsId() throws IEMRException {
+        when(hypertensionScreeningRepo.save(hypertensionScreening)).thenReturn(hypertensionScreening);
+
+        Long result = ncdScreeningService.saveHypertensionDetails(hypertensionScreening);
+
+        assertEquals(1L, result);
+        verify(hypertensionScreeningRepo).save(hypertensionScreening);
+    }
+
+    @Test
+    void saveHypertensionDetails_repoReturnsNull_throwsIEMRException() {
+        when(hypertensionScreeningRepo.save(hypertensionScreening)).thenReturn(null);
+
+        IEMRException ex = assertThrows(IEMRException.class,
+                () -> ncdScreeningService.saveHypertensionDetails(hypertensionScreening));
+
+        assertEquals("Error while saving hypertension screening data", ex.getMessage());
+    }
+
+    @Test
+    void saveHypertensionDetails_repoReturnsObjectWithNullId_throwsIEMRException() {
+        HypertensionScreening noId = new HypertensionScreening();
+        when(hypertensionScreeningRepo.save(noId)).thenReturn(noId);
+
+        IEMRException ex = assertThrows(IEMRException.class,
+                () -> ncdScreeningService.saveHypertensionDetails(noId));
+
+        assertEquals("Error while saving hypertension screening data", ex.getMessage());
+    }
+
+    // -------------------- saveOralCancerDetails --------------------
+
+    @Test
+    void saveOralCancerDetails_success_returnsId() throws IEMRException {
+        when(oralCancerScreeningRepo.save(oralCancerScreening)).thenReturn(oralCancerScreening);
+
+        Long result = ncdScreeningService.saveOralCancerDetails(oralCancerScreening);
+
+        assertEquals(1L, result);
+        verify(oralCancerScreeningRepo).save(oralCancerScreening);
+    }
+
+    @Test
+    void saveOralCancerDetails_repoReturnsNull_throwsIEMRException() {
+        when(oralCancerScreeningRepo.save(oralCancerScreening)).thenReturn(null);
+
+        IEMRException ex = assertThrows(IEMRException.class,
+                () -> ncdScreeningService.saveOralCancerDetails(oralCancerScreening));
+
+        assertEquals("Error while saving oral screening", ex.getMessage());
+    }
+
+    // -------------------- saveBreastCancerDetails --------------------
+
+    @Test
+    void saveBreastCancerDetails_success_returnsId() throws IEMRException {
+        when(breastCancerScreeningRepo.save(breastCancerScreening)).thenReturn(breastCancerScreening);
+
+        Long result = ncdScreeningService.saveBreastCancerDetails(breastCancerScreening);
+
+        assertEquals(1L, result);
+        verify(breastCancerScreeningRepo).save(breastCancerScreening);
+    }
+
+    @Test
+    void saveBreastCancerDetails_repoReturnsNull_throwsIEMRException() {
+        when(breastCancerScreeningRepo.save(breastCancerScreening)).thenReturn(null);
+
+        IEMRException ex = assertThrows(IEMRException.class,
+                () -> ncdScreeningService.saveBreastCancerDetails(breastCancerScreening));
+
+        assertEquals("Error while saving breast cancer screening", ex.getMessage());
+    }
+
+    // -------------------- saveCervicalDetails --------------------
+
+    @Test
+    void saveCervicalDetails_success_returnsId() throws IEMRException {
+        when(cervicalCancerScreeningRepo.save(cervicalCancerScreening)).thenReturn(cervicalCancerScreening);
+
+        Long result = ncdScreeningService.saveCervicalDetails(cervicalCancerScreening);
+
+        assertEquals(1L, result);
+        verify(cervicalCancerScreeningRepo).save(cervicalCancerScreening);
+    }
+
+    @Test
+    void saveCervicalDetails_repoReturnsNull_throwsIEMRException() {
+        when(cervicalCancerScreeningRepo.save(cervicalCancerScreening)).thenReturn(null);
+
+        IEMRException ex = assertThrows(IEMRException.class,
+                () -> ncdScreeningService.saveCervicalDetails(cervicalCancerScreening));
+
+        assertEquals("Error while saving cervical screening", ex.getMessage());
+    }
+
+    // -------------------- saveCbacDetails --------------------
+
+    @Test
+    void saveCbacDetails_success_returnsId() throws IEMRException {
+        when(cbacDetailsRepo.save(cbacDetails)).thenReturn(cbacDetails);
+
+        Long result = ncdScreeningService.saveCbacDetails(cbacDetails);
+
+        assertEquals(1L, result);
+        verify(cbacDetailsRepo).save(cbacDetails);
+    }
+
+    @Test
+    void saveCbacDetails_repoReturnsNull_throwsIEMRException() {
+        when(cbacDetailsRepo.save(cbacDetails)).thenReturn(null);
+
+        IEMRException ex = assertThrows(IEMRException.class,
+                () -> ncdScreeningService.saveCbacDetails(cbacDetails));
+
+        assertEquals("Error while saving Cbac details", ex.getMessage());
+    }
+}


### PR DESCRIPTION
## Summary

- Added 14 unit tests for NCD Screening service covering all 6 screening methods with success and failure paths
- Added 9 unit tests for Login service covering 4 methods
- Replaced bare `RuntimeException` and generic `Exception` throws with domain-specific `IEMRException` in General OPD service

## Test plan

- [ ] Run `NCDScreeningServiceImplTest` — all 14 tests pass
- [ ] Run `IemrMmuLoginServiceImplTest` — all 9 tests pass
- [ ] Verify `saveNurseData`, `saveDoctorData`, `updateGeneralOPDDoctorData` throw `IEMRException` on failure instead of leaking as unhandled 500 errors