### PR TITLE
fix: return correct HTTP status codes and remove patient data logging in GeneralOPDController

### DIFF
--- a/src/main/java/com/iemr/hwc/controller/generalOPD/GeneralOPDController.java
+++ b/src/main/java/com/iemr/hwc/controller/generalOPD/GeneralOPDController.java
@@ -31,6 +31,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -80,7 +81,7 @@ public class GeneralOPDController {
 	 */
 	@Operation(summary = "Save general OPD data collected by nurse")
 	@PostMapping(value = { "/save/nurseData" })
-	public String saveBenGenOPDNurseData(@RequestBody String requestObj,
+	public ResponseEntity<String> saveBenGenOPDNurseData(@RequestBody String requestObj,
 			@RequestHeader(value = "Authorization") String Authorization) throws Exception {
 		OutputResponse response = new OutputResponse();
 
@@ -91,7 +92,7 @@ public class GeneralOPDController {
 			jsnOBJ = jsnElmnt.getAsJsonObject();
 
 			try {
-				logger.info("Request object for GeneralOPD nurse data saving :" + requestObj);
+				logger.info("Request received for GeneralOPD nurse data saving");
 
 				if (jsnOBJ != null) {
 					String genOPDRes = generalOPDServiceImpl.saveNurseData(jsnOBJ, Authorization);
@@ -105,7 +106,7 @@ public class GeneralOPDController {
 				response.setError(5000, e.getMessage());
 			}
 		}
-		return response.toString();
+		return response.toStringWithHttpStatus();
 	}
 
 	/**


### PR DESCRIPTION
## 📋 Description

Proof of concept fix for the HTTP status code and patient data logging issues identified in PSMRI/AMRIT#153.

**Problem 1: Always HTTP 200**
Every controller method returned `String` instead of `ResponseEntity`, meaning the HTTP status was always 200 — even on failures. The error details were buried in the JSON body, forcing clients to parse the body to detect failures instead of using standard HTTP semantics. The fix already existed — `OutputResponse.toStringWithHttpStatus()` was implemented but never used. This PR uses it.

**Problem 2: Patient data in logs**
Every controller logged the full raw `requestObj` at INFO level. These request bodies contain patient vitals, medical history, examination details and prescriptions. INFO logs are always-on in production — meaning sensitive patient data was being stored in plain text logs. Replaced with a generic log message containing no patient data.

Fixes: PSMRI/AMRIT#153

---

## ✅ Type of Change

- [x] 🐞 **Bug fix** (non-breaking change which resolves an issue)
- [x] 🛠 **Refactor** (change that is neither a fix nor a new feature)

---

## ℹ️ Additional Information

**Scope:** One method in GeneralOPDController as proof of concept.

**Changes made:**
- Return type: `String` → `ResponseEntity<String>`
- `response.toString()` → `response.toStringWithHttpStatus()`
- Raw requestObj logging removed, replaced with generic message

**Next steps if approved:**
- Add `@ControllerAdvice` global exception handler
- Extend to remaining 20+ controllers
- Fix BAD_REQUEST mapped to 404 instead of 400 in OutputResponse.java

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed nurse OPD data endpoint to properly return appropriate HTTP status codes for requests, ensuring accurate API response status handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PSMRI/HWC-API/pull/211)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->