### PR TITLE
fix: correct BAD_REQUEST status code and deduplicate exception codes in OutputResponse

### DIFF
--- a/src/main/java/com/iemr/hwc/utils/response/OutputResponse.java
+++ b/src/main/java/com/iemr/hwc/utils/response/OutputResponse.java
@@ -50,9 +50,9 @@ public class OutputResponse {
 	public static final int CODE_EXCEPTION = 5005;
 	public static final int ENVIRONMENT_EXCEPTION = 5006;
 	public static final int PARSE_EXCEPTION = 5007;
-	public static final int SWYMED_EXCEPTION = 5010;
-	public static final int TM_EXCEPTION = 5010;
-	public static final int BAD_REQUEST = 404;
+	public static final int SWYMED_EXCEPTION = 5008;
+	public static final int TM_EXCEPTION = 5009;
+	public static final int BAD_REQUEST = 400;
 
 	@Expose
 	private int statusCode = GENERIC_FAILURE;


### PR DESCRIPTION
## 📋 Description

Fixes incorrect HTTP status code constants in OutputResponse.java that affect every API response across HWC-API.

**Problem 1: BAD_REQUEST = 404**
`BAD_REQUEST` was set to `404` (Not Found) instead of `400` (Bad Request). This caused every bad request response to carry the semantically wrong HTTP status code, making it impossible to distinguish "resource not found" from "malformed request" errors.

**Problem 2: Duplicate exception codes**
`SWYMED_EXCEPTION` and `TM_EXCEPTION` both used error code `5010`, making them completely indistinguishable in logs and error tracking systems.

Related to PSMRI/AMRIT#153

## ✅ Type of Change
- [x] 🐞 Bug fix

## ℹ️ Additional Information
**Changes — 1 file, 3 lines:**
- `BAD_REQUEST`: 404 → 400
- `SWYMED_EXCEPTION`: 5010 → 5008
- `TM_EXCEPTION`: 5010 → 5009

These constants are used across 20+ controllers in HWC-API.